### PR TITLE
OAuth compliant authorization header

### DIFF
--- a/Sources/GitLabSwift/Core/GLApi+Config.swift
+++ b/Sources/GitLabSwift/Core/GLApi+Config.swift
@@ -75,6 +75,6 @@ public struct Config {
     func authenticationToken() -> (key: String, value: String)? {
         guard let token else { return nil }
         
-        return ("PRIVATE-TOKEN", token)
+        return ("Authorization", "Bearer " + token)
     }
 }


### PR DESCRIPTION
# Problem #

Using `PRIVATE-TOKEN` header users can only use personal/project/group tokens, and can't use OAuth tokens.

# Solution #

According to gitlab documentation https://docs.gitlab.com/ee/api/rest/#personalprojectgroup-access-tokens there's also OAuth compliant way to authorize which works with personal/project/group and OAuth tokens.

# Checks #

- [x] Checked on real application